### PR TITLE
Configurable throttle + securely dispose sqllite connections

### DIFF
--- a/ff16.utility.livenexeditor/Config.cs
+++ b/ff16.utility.livenexeditor/Config.cs
@@ -22,6 +22,11 @@ public class Config : Configurable<Config>
     [Description("Folder to monitor for nxd/sqlite files")]
     [DefaultValue("")]
     public string MonitorPath { get; set; } = "";
+
+    [DisplayName("Throttle before injecting")]
+    [Description("Wait for the specified amount of milliseconds before injecting the changes into the game\nDefaults: 1000 for NXD, 4000 for SQL DB")]
+    [DefaultValue(4000)]
+    public int ThrottleMilliseconds { get; set; }
 }
 
 /// <summary>

--- a/ff16.utility.livenexeditor/ff16.utility.livenexeditor.csproj
+++ b/ff16.utility.livenexeditor/ff16.utility.livenexeditor.csproj
@@ -39,7 +39,7 @@
   <ItemGroup>
 	<PackageReference Include="ff16.utility.modloader.Interfaces" Version="1.0.5" />
 	<PackageReference Include="FF16Framework.Interfaces" Version="1.1.0" />
-	<PackageReference Include="FF16Tools.Files" Version="1.1.2" />
+	<PackageReference Include="FF16Tools.Files" Version="1.2.0" />
 	<PackageReference Include="Reloaded.Memory" Version="9.4.2" />
     <PackageReference Include="Reloaded.Memory.Sigscan" Version="3.1.9" />
     <PackageReference Include="Reloaded.Memory.SigScan.ReloadedII.Interfaces" Version="1.2.0" />


### PR DESCRIPTION
With this pull request, I wish to propose some minor improvements to your code base. I am happy to make any change required, especially any unwanted change.

### Configurable throttling

This is the biggest but also simplest change. For my kind of workflow, zero latency was what I needed. I am not sure about other people's workflow, therefore I put it as something configurable that defaults by 4 seconds.

### Update FF16Tools.Files

Trivial change, but required to not let this tool crashing with sqllite produced with the latest NXD changes.

### Removal of opened connections

For the sake of avoiding the sqllite database to be either locked or to avoid issue with caching, I am proposing to open and close connections strictly when they are needed, instead of opening a connection and store them in `_connections`. Opening a closing a sqllite connection is a fast and trivial operation, it will not be a cause of trouble.

### Tearing down

I put a `_trackedSqlFiles` to query all the tracked sqllite files, used when a `TearDownSql`. Speaking of, `TearDownSql` clean-ups all the databases asynchronously. It should only save a few milliseconds during the teardown process, but I do not see why the operation should be done synchronously.

### Minor other considerations

I have been thinking to make the code fully asynchronous. But I observed that the FF16Tools Framework is not meant to support concurrent API calls. For the sake of not risking to break stuff, I will leave it be.
